### PR TITLE
Resolve the 404 error after running the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk --update add nginx
 
 COPY 2048 /usr/share/nginx/html
 
+COPY default.conf /etc/nginx/http.d/default.conf
+
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location = /404.html {
+        internal;
+ 

--- a/default.conf
+++ b/default.conf
@@ -11,4 +11,5 @@ server {
 
     location = /404.html {
         internal;
- 
+    }
+}


### PR DESCRIPTION
I've added the default.conf which can read the index.html file from the /usr/share/nginx/html folder